### PR TITLE
Use default terminal colors.

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -500,6 +500,7 @@ def csv_sniff(fn, enc):
 
 
 def main(stdscr, data):
+    curses.use_default_colors()
     Viewer(stdscr, data).run()
 
 


### PR DESCRIPTION
After calling curses.initscr() or curses.wrapper() a call to use_default_colors() is also needed to initialize the default foreground/background colors for A_NORMAL/A_REVERSE/etc. Without this call, A_NORMAL will forcedly be white on black, which is incorrect if terminal colors have been changed.
