### PR TITLE
Disable block cursor.

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -586,6 +586,7 @@ def csv_sniff(fn, enc):
 
 def main(stdscr, data):
     curses.use_default_colors()
+    curses.curs_set(False)
     Viewer(stdscr, data).run()
 
 


### PR DESCRIPTION
Disable the cursor since we have a clear indication of focus anyway.
