### PR TITLE
Support for dict, ndarray and pandas objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
 language: python
 python:
+  # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
   - "3.2"
   - "3.3"
   - "3.4"
-
-# command to install dependencies
 install:
-  - "pip install ."
+  - sudo apt-get update
+  # You may want to periodically update this, although the conda update
+  # conda line below will keep everything up-to-date.  We do this
+  # conditionally because it saves us some downloading if the version is
+  # the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
 
-# command to run tests
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas
+  - source activate test-environment
+  - python setup.py install
+
 script: python -m unittest discover
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
+  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 install:

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -1090,12 +1090,14 @@ def process_data(data, enc=None, delim=None, **kwargs):
         # If data is from a dict object.
         if kwargs['orient'] == 'columns':
             header = [str(i) for i in data.keys()]
-            data = zip(*[data[i] for i in data.keys()])
+            data = list(zip(*[data[i] for i in data.keys()]))
         elif kwargs['orient'] == 'index':
             data =  [[i[0]] + i[1] for i in data.items()]
             header = [str(i) for i in range(len(data[0]))]
         if sys.version_info.major < 3:
             data = pad_data(py2_list_to_unicode(data))
+        else:
+            data = [[str(j) for j in i] for i in pad_data(data)]
         return {'data' : data, 'header' : header}
     
     elif process_type == 'pandas':
@@ -1151,8 +1153,9 @@ def process_data(data, enc=None, delim=None, **kwargs):
     else:
         # If data is from a list of lists.
         if sys.version_info.major < 3:
-            data = py2_list_to_unicode(data)
-        data = [[str(j) for j in i] for i in pad_data(data)]
+            data = pad_data(py2_list_to_unicode(data))
+        else:
+            data = [[str(j) for j in i] for i in pad_data(data)]
         if len(data) > 1:
             header = data[0]
             data = data[1:]

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -94,8 +94,8 @@ class Viewer:
         os.unsetenv('LINES')
         os.unsetenv('COLUMNS')
         self.scr = args[0]
-	if type(args[1]) == pandas.core.frame.DataFrame:
-	    self.data = args[1].values.tolist()
+        if type(args[1]) == pandas.core.frame.DataFrame:
+            self.data = args[1].values.tolist()
             self.header_offset_orig = 3
             self.header_offset = 3
             self.header = list(pandas.Series(args[1].columns).astype(unicode))
@@ -105,7 +105,7 @@ class Viewer:
             self.column_gap = kwargs.get('column_gap')
             self._init_column_widths(kwargs.get('column_width'),
                                      kwargs.get('column_widths'))
-	else:
+        else:
             self.data = [[str(j) for j in i] for i in args[1]]
             self.header_offset_orig = 3
             self.header = self.data[0]

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -24,7 +24,6 @@ from operator import itemgetter
 from subprocess import Popen, PIPE
 from textwrap import wrap
 import unicodedata
-import pandas
 
 
 if sys.version_info.major < 3:
@@ -94,11 +93,11 @@ class Viewer:
         os.unsetenv('LINES')
         os.unsetenv('COLUMNS')
         self.scr = args[0]
-        if type(args[1]) == pandas.core.frame.DataFrame:
+        if type(args[1]).__name__ == 'DataFrame':
             self.data = args[1].values.tolist()
             self.header_offset_orig = 3
             self.header_offset = 3
-            self.header = list(pandas.Series(args[1].columns).astype(unicode))
+            self.header = [unicode(i) for i in args[1].columns]
             self.num_data_columns = len(self.header)
             self._init_double_width(kwargs.get('double_width'))
             self.column_width_mode = kwargs.get('column_width')
@@ -1266,7 +1265,7 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
                 else:
                     new_data = data
 
-                if type(new_data) == pandas.core.frame.DataFrame:
+                if type(new_data).__name__ == 'DataFrame':
                     buf = process_df(new_data)
 
                 elif new_data:

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -1151,8 +1151,8 @@ def process_data(data, enc=None, delim=None, **kwargs):
     csv_data = [[str(j) for j in i] for i in pad_data(csv_data)]
     
     if len(csv_data) > 1:
-        csv_data = csv_data[1:]
         csv_header = csv_data[0]
+        csv_data = csv_data[1:]
     else:
         csv_header = [str(i) for i in range(len(csv_data[0]))]
     return {'data': csv_data, 'header': csv_header}

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -263,7 +263,7 @@ class Viewer:
     def goto_y(self, y):
         y = max(min(len(self.data), y), 1)
         if self.win_y < y <= self.win_y + \
-                (self.max_y - self.header_offset):
+                (self.max_y - self.header_offset - self._search_win_open):
             # same screen, change y appropriately.
             self.y = y - 1 - self.win_y
         elif y <= self.win_y:
@@ -272,8 +272,10 @@ class Viewer:
             self.win_y = y - 1
         else:
             # going forward
-            self.win_y = y - (self.max_y - self.header_offset)
-            self.y = (self.max_y - self.header_offset) - 1
+            self.win_y = y - (self.max_y - self.header_offset -
+                              self._search_win_open)
+            self.y = (self.max_y - self.header_offset -
+                      self._search_win_open) - 1
 
     def goto_row(self):
         m = self.consume_modifier(len(self.data))

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -96,11 +96,7 @@ class Viewer:
         self.data = args[1]['data']
         self.header_offset_orig = 3
         self.header = args[1]['header']
-#        if len(self.data) > 1:
         self.header_offset = self.header_offset_orig
-#        else:
-            # Don't make one line file a header row
-#            self.header_offset = self.header_offset_orig - 1
         self.num_data_columns = len(self.header)
         self._init_double_width(kwargs.get('double_width'))
         self.column_width_mode = kwargs.get('column_width')
@@ -1129,8 +1125,9 @@ def process_data(data, enc=None, delim=None, **kwargs):
         if len(data.shape) == 1:
             data = np.array((data,))
         
-        header = [str(i) for i in range(data.shape[1])]
-        
+        header = [str(i) for i in range(data.shape[1])] 
+        data = data.tolist()
+
         return {'data': data, 'header': header}
 
     if enc is None:

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -1266,7 +1266,11 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
                     new_data = data
 
                 if type(new_data).__name__ == 'DataFrame':
-                    buf = process_df(new_data)
+                    if new_data.any().any():
+                        buf = process_df(new_data)
+                    else:
+                        # empty dataframe
+                        return 1
 
                 elif new_data:
                     buf = process_data(new_data, enc, delimiter)

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -1105,7 +1105,10 @@ def process_data(data, enc=None, delim=None, **kwargs):
             data = pd.DataFrame(data)
         elif data.__class__.__name__ == 'Panel':
             data = data.to_frame()
-        data = data.reset_index().fillna('').astype(object).astype(str)
+        data = data.reset_index()
+        if len(data.select_dtypes(include=['datetime']).columns) > 0:
+            data[data.select_dtypes(include=['datetime']).columns] = data[data.select_dtypes(include=['datetime']).columns].astype(object)
+        data = data.fillna('').astype(str)
         return {'data': data.values.tolist(), 'header': [str(i) for i in data.columns]}
 
     elif process_type == 'numpy':

--- a/tests/test_tabview.py
+++ b/tests/test_tabview.py
@@ -160,14 +160,14 @@ class TestTabviewIntegration(unittest.TestCase):
                        column_widths=None, trunc_char='…',
                        search_str=None)
     
-#    def test_tabview_array_2d(self):
-#        curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0], encoding='utf-8').values),
-#                       start_pos=(0, 0), column_width=20, column_gap=2,
-#                       column_widths=None, trunc_char='…',
-#                       search_str=None)
+    def test_tabview_array_2d(self):
+        curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0]).values),
+                       start_pos=(0, 0), column_width=20, column_gap=2,
+                       column_widths=None, trunc_char='…',
+                       search_str=None)
 
     def test_tabview_pandas_dataframe(self):
-        curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0], encoding='utf-8')),
+        curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0])),
                        start_pos=(0, 0), column_width=20, column_gap=2,
                        column_widths=None, trunc_char='…',
                        search_str=None)

--- a/tests/test_tabview.py
+++ b/tests/test_tabview.py
@@ -142,13 +142,13 @@ class TestTabviewIntegration(unittest.TestCase):
                        column_widths=[4, 5, 1], trunc_char='>',
                        search_str=None)
 
-    def test_tabview_array_dict_columns(self):
+    def test_tabview_dict_columns(self):
         curses.wrapper(self.main, t.process_data(dict_1, orient='columns'),
                        start_pos=(0, 0), column_width=20, column_gap=2,
                        column_widths=None, trunc_char='…',
                        search_str=None)
 
-    def test_tabview_array_dict_index(self):
+    def test_tabview_dict_index(self):
         curses.wrapper(self.main, t.process_data(dict_1, orient='index'),
                        start_pos=(0, 0), column_width=20, column_gap=2,
                        column_widths=None, trunc_char='…',
@@ -162,13 +162,13 @@ class TestTabviewIntegration(unittest.TestCase):
     
     def test_tabview_array_2d(self):
         curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0]).values),
-                       start_pos=(0, 0), column_width=20, column_gap=2,
+                       start_pos=(0, 0), column_width='mode', column_gap=2,
                        column_widths=None, trunc_char='…',
                        search_str=None)
 
     def test_tabview_pandas_dataframe(self):
         curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0])),
-                       start_pos=(0, 0), column_width=20, column_gap=2,
+                       start_pos=(0, 0), column_width='mode', column_gap=2,
                        column_widths=None, trunc_char='…',
                        search_str=None)
 

--- a/tests/test_tabview.py
+++ b/tests/test_tabview.py
@@ -160,11 +160,11 @@ class TestTabviewIntegration(unittest.TestCase):
                        column_widths=None, trunc_char='…',
                        search_str=None)
     
-    def test_tabview_array_2d(self):
-        curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0], encoding='utf-8').values),
-                       start_pos=(0, 0), column_width=20, column_gap=2,
-                       column_widths=None, trunc_char='…',
-                       search_str=None)
+#    def test_tabview_array_2d(self):
+#        curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0], encoding='utf-8').values),
+#                       start_pos=(0, 0), column_width=20, column_gap=2,
+#                       column_widths=None, trunc_char='…',
+#                       search_str=None)
 
     def test_tabview_pandas_dataframe(self):
         curses.wrapper(self.main, t.process_data(pd.read_csv(data_1[0], encoding='utf-8')),

--- a/tests/test_tabview.py
+++ b/tests/test_tabview.py
@@ -70,7 +70,8 @@ class TestTabviewUnits(unittest.TestCase):
         """
         fn, _, sample_data = info
         code = 'utf-8'  # Per top line of file
-        res = t.process_data(self.data(fn))
+        fn_proc = t.process_data(self.data(fn))
+        res = [fn_proc['header']] + fn_proc['data']
         # Check that process_file returns a list of lists
         self.assertEqual(type(res), list)
         self.assertEqual(type(res[0]), list)


### PR DESCRIPTION
# Overview

The additions shown in the following pull request implement support for dicts, pandas objects and numpy ndarrays.

In this implementation, the `process_data` function handles the majority of the data formatting. Instead of returning the data and headers together as a single object, the `process_data` function now returns a dict with two entries:
- 'data': which contains the actual data
- 'header': which contains the header for the data*

This allows the Viewer class to make fewer assumptions about the data that it is receiving. It also allows for faster (vectorized) formatting of data for pandas and numpy objects by avoiding computationally expensive list comprehensions.

In a previous pull request, some contributors raised concerns about whether support for pandas objects should be part of the pandas library, rather than part of the tabview library. Personally, I would prefer a standalone curses library with some support for pandas objects. I regularly work with pandas, numpy, dict and csv objects, and it would be nice to have a curses viewer that can deal with all of these cases in an interactive setting. Moreover, because numpy and pandas have become the de facto standard libraries for working with array-like data in python, I think it makes sense to add support for at least these libraries.

Below, I have tested the new implementation with lists of lists, dicts, pandas objects (`Series`, `DataFrame` and `Panel`) and numpy `ndarray`. You can see the output by running my fork of tabview (branch `feat`):

``` python
import tabview
import pandas as pd
import numpy as np
import pandas.io.data as web
import datetime

#### LISTS

#3-row list; header defaults to the first row.

sample_list = [[5,4,3,2,1], [1,2,3,4,5], ['a', 'b', 'c', 'd', 'e']]
tabview.view(sample_list)

#1-row list; an integer header is appended automatically.

sample_list_2 = [[1,2,3,4,5]]
tabview.view(sample_list_2)

#### DICTS

sample_dict = {1:[0,1,2,3,4,5], 2:[5,4,3,2,1,0]}

# column view (default); dictionary keys become the header.
tabview.view(sample_dict)

# index view; dictionary keys become the first column (index).
tabview.view(sample_dict, orient='index')

#### PANDAS OBJECTS

# DataFrame
df = pd.read_csv('../sample/data_ohlcv.csv')
tabview.view(df)

# Series
tabview.view(df['Date'])

# Panel (from previous pull request)
start = datetime.datetime(2010, 1, 1)
end = datetime.datetime(2013, 1, 27)
panel = web.DataReader(["F", "YHOO"], 'yahoo', start, end)
tabview.view(panel)

#### NUMPY ARRAYS

#1-dimensional array
test_array_1 = np.array([1,3,5,3,5,np.nan])
tabview.view(test_array_1)

#2-dimensional array
tabview.view(df.values)

#### CSV (STILL WORKS)

tabview.view('../sample/data_ohlcv.csv')
tabview.view('../sample/unicode-example-utf8.txt')
```
# Summary of changes:
- `Viewer` now accepts dicts containing (1) data and (2) header information.
- `data_list_or_file` changed to more generalized `input_type`
- `process_data` now formats dicts, pandas objects, and ndarrays and returns a dict of data/header info.
- `view`: exception handling for `locale.getlocate(locale.LC_ALL)`

*Note on headers: There needs to be some sort of parameter for header preferences in tabview.view. In this implementation, I just guessed as to what users would most likely want.
