### PR TITLE
add note about package not maintained and link to visidata in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@
 Tabview  
 =========
 
+**No longer maintained. Check https://github.com/saulpw/visidata**
+
 View a CSV file in a spreadsheet-like display.
 
 Posted by Scott Hansen <firecat4153@gmail.com>


### PR DESCRIPTION
Firecat's comment at https://github.com/TabViewer/tabview/pull/116#issuecomment-416267730

This would make it easier for new-comers to find the visidata repository if they land on tabview.
From firecat's comment

> I also feel like the Visidata project has eclipsed pretty much all the goals I originally had for the project. I don't know how much Pandas/numpy integration it has, but I'd definitely check. Visidata has a much larger scope, but it still seemed plenty zippy the few times I've tested it.