### PR TITLE
Add pbcopy to support MacOS

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -638,7 +638,7 @@ class Viewer:
         except KeyError:
             return
         for cmd in (['xclip', '-selection', 'clipboard'],
-                    ['xsel', '-i']):
+                    ['xsel', '-i'], ['pbcopy']):
             try:
                 Popen(cmd, stdin=PIPE,
                       universal_newlines=True).communicate(input=s)


### PR DESCRIPTION
`pbcopy` is used to work with clipboard in MacOS, so it will help all mac os users )